### PR TITLE
Add state machine script skeleton plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/statemachine/StateMachineConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/statemachine/StateMachineConfig.java
@@ -1,0 +1,17 @@
+package net.runelite.client.plugins.microbot.statemachine;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("statemachine")
+public interface StateMachineConfig extends Config {
+    @ConfigItem(
+            keyName = "example",
+            name = "Example Option",
+            description = "Example configuration item"
+    )
+    default boolean example() {
+        return false;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/statemachine/StateMachinePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/statemachine/StateMachinePlugin.java
@@ -1,0 +1,41 @@
+package net.runelite.client.plugins.microbot.statemachine;
+
+import static net.runelite.client.plugins.PluginDescriptor.Mocrosoft;
+
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+
+@PluginDescriptor(
+        name = Mocrosoft + "State Machine",
+        description = "Template for building state machine scripts",
+        tags = {"microbot", "template"},
+        enabledByDefault = false
+)
+@Slf4j
+public class StateMachinePlugin extends Plugin {
+
+    @Inject
+    private StateMachineConfig config;
+
+    @Inject
+    private StateMachineScript script;
+
+    @Provides
+    StateMachineConfig provideConfig(ConfigManager configManager) {
+        return configManager.getConfig(StateMachineConfig.class);
+    }
+
+    @Override
+    protected void startUp() {
+        script.run(config);
+    }
+
+    @Override
+    protected void shutDown() {
+        script.shutdown();
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/statemachine/StateMachineScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/statemachine/StateMachineScript.java
@@ -1,0 +1,50 @@
+package net.runelite.client.plugins.microbot.statemachine;
+
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.plugins.microbot.Microbot;
+import net.runelite.client.plugins.microbot.Script;
+
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class StateMachineScript extends Script {
+
+    private State state = State.INIT;
+
+    private enum State {
+        INIT,
+        IDLE,
+        PROCESS,
+        EXIT
+    }
+
+    public boolean run(StateMachineConfig config) {
+        mainScheduledFuture = scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            try {
+                if (!Microbot.isLoggedIn() || !super.run()) {
+                    return;
+                }
+
+                switch (state) {
+                    case INIT:
+                        state = State.IDLE;
+                        break;
+                    case IDLE:
+                        // transition logic here
+                        break;
+                    case PROCESS:
+                        // main task logic here
+                        state = State.EXIT;
+                        break;
+                    case EXIT:
+                        shutdown();
+                        break;
+                }
+            } catch (Exception e) {
+                log.error("Error in state machine", e);
+                shutdown();
+            }
+        }, 0, 100, TimeUnit.MILLISECONDS);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable plugin template for state machine development
- provide basic script illustrating a simple INIT/IDLE/PROCESS/EXIT loop

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b1ad03994c833094effdfdf287622a